### PR TITLE
Fix bug causing context menu to close when using ctrl-click as the trigger

### DIFF
--- a/bootstrap-contextmenu.js
+++ b/bootstrap-contextmenu.js
@@ -38,7 +38,9 @@
         var $el = $(element).on('contextmenu.context.data-api', this.toggle);
         var $target = $($el.attr('data-target'));
         $('html').on('click.context.data-api', function () {
+          if (!e.ctrlKey) {
             $target.removeClass('open');
+          }
         });
       }
 
@@ -119,9 +121,12 @@
     return $.extend(tp, Y, X);
   }
 
-  function clearMenus() {
-    getMenu($(toggle))
-        .removeClass('open');
+  function clearMenus(e) {
+    if (!e.ctrlKey) {
+      getMenu($(toggle))
+          .removeClass('open');
+    }
+
   }
 
   /* CONTEXT MENU PLUGIN DEFINITION


### PR DESCRIPTION
Heya,

This fixes an issue that only seems to occur when using ctrl-click on OSX with webkit browsers to bring up the context menu. From debugging, I was able to see that a click event is fired that causes the context menu to close right after it is opened by the contextmenu event.
