### PR TITLE
Add onItem argument element where the event was set

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ See a [new Fiddle] [id] showing the javascript parameters
 Change log
 ----------
 
+24/05/2013
+- Added `onItem` argument element where the event was set
+
 13/05/2013
 - Added `onItem` option which is called whenever an item is clicked in the context menu
 - Added before, target options to javascript usage (`before` and `target`)
@@ -43,7 +46,7 @@ Call the context menu via JavaScript:
       before: function(e,element) {
         // execute code before context menu if shown
       },
-      onItem: function(e, element) {
+      onItem: function(e, item, element) {
         // execute on menu item selection
       }
     })
@@ -58,7 +61,8 @@ Call the context menu via JavaScript:
 `onItem` - function to be called when a menu item in contextmenu is clicked. Useful when you want to execute a specific function when an item is clicked. It is passed two parameters,
 
   - `e` - the click event.
-  - `element` - the element of the menu item
+  - `item` - the element of the menu item
+  - `element` - the element where the event was set
 
 
 Example

--- a/bootstrap-contextmenu.js
+++ b/bootstrap-contextmenu.js
@@ -96,7 +96,7 @@
 			var $target = $(this.$element.attr('data-target'));
 
 			$target.on('click.context.data-api', function (e) {
-				_this.onItem.call(this,e,$(e.target));
+				_this.onItem.call(this,e,$(e.target),_this.$element);
 			});
 
 			$('html').on('click.context.data-api', function (e) {


### PR DESCRIPTION
`onItem: function(e, element) { }` to `onItem: function(e, item, element) { }`  

`item` argument is old `element` argument.  
`element` argument is the same as the before method's `element` argument.  
