### PR TITLE
Fix calling onItem for all the instances of contextmenu that use the same dropdown.

### DIFF
--- a/bootstrap-contextmenu.js
+++ b/bootstrap-contextmenu.js
@@ -68,6 +68,7 @@
 			var tp = this.getPosition(e, $menu);
 			$menu.attr('style', '')
 				.css(tp)
+				.data('_context_this_ref', this)
 				.addClass('open');
 
 
@@ -96,7 +97,9 @@
 			var $target = $(this.$elements.attr('data-target'));
 
 			$target.on('click.context.data-api', function (e) {
-				_this.onItem.call(this,e,$(e.target));
+				if($(this).data('_context_this_ref') == _this) {
+					_this.onItem.call(this,e,$(e.target));
+				}
 			});
 
 			$('html').on('click.context.data-api', function (e) {


### PR DESCRIPTION
Added a _context_this_ref in the data of the shown context menu to call only the onItem callback function that is initialized for this istance of the contextmenu.

This was causing a problem if you initialize multiple times the Contextmenu and all of them use same dropdown element. In this case each onItem is called instead of only the one that was initialized for the specific element/selector.
