### PR TITLE
fixing CDN references on demo.html page

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -7,14 +7,13 @@
     <meta name="author" content="">
 
     <!-- Le styles -->
-    <link href="http://twitter.github.com/bootstrap/assets/css/bootstrap.css" rel="stylesheet">
-  	<link href="http://twitter.github.com/bootstrap/assets/js/google-code-prettify/prettify.css" rel="stylesheet">
+	  <link href="http://cdnjs.cloudflare.com/ajax/libs/prettify/r224/prettify.css" type="text/css">
     <style>
       body {
         padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
       }
     </style>
-    <link href="http://twitter.github.com/bootstrap/assets/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
@@ -22,11 +21,6 @@
     <![endif]-->
 
     <!-- Le fav and touch icons -->
-    <link rel="shortcut icon" href="http://twitter.github.com/bootstrap/assets/ico/favicon.ico">
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="http://twitter.github.com/bootstrap/assets/ico/apple-touch-icon-144-precomposed.png">
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="http://twitter.github.com/bootstrap/assets/ico/apple-touch-icon-114-precomposed.png">
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="http://twitter.github.com/bootstrap/assets/ico/apple-touch-icon-72-precomposed.png">
-    <link rel="apple-touch-icon-precomposed" href="http://twitter.github.com/bootstrap/assets/ico/apple-touch-icon-57-precomposed.png">
   </head>
 
   <body onload="prettyPrint()">
@@ -111,9 +105,9 @@ $('.context').contextmenu();</pre>
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="assets/jquery.js"></script>
+    <script src="http://codeorigin.jquery.com/jquery-1.10.2.min.js"></script>
     <script src="../bootstrap-contextmenu.js"></script>
-    <script src="http://twitter.github.com/bootstrap/assets/js/google-code-prettify/prettify.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r224/prettify.js"></script>
     <script type="text/javascript">
       // Demo 2
       $('#main').contextmenu({


### PR DESCRIPTION
Hi sydcanem,

First off, I wanted to say thank you for making a really cool/useful plugin! When I opened up the demo.html page, I got the following:

![screen shot 2013-08-20 at 9 43 26 pm](https://f.cloud.github.com/assets/437318/998514/49e290a0-0a04-11e3-9769-356ab1b00041.png)

The page looked un-styled, and the console was throwing the following error messages:

```
 Uncaught SyntaxError: Unexpected token <                                     getbootstrap.com/2.3.2/:1
 Uncaught ReferenceError: prettyPrint is not defined                              demo.html:32
```

I just updated some of the CDN references to point towards valid resources (for Bootstrap, JQuery, etc...) so that the demo page renders correctly. After I made the updates, the page was rendering properly and not throwing the errors. I think this would be a good fix to ensure the demo is working properly.

Thanks!
-Rohit K
