### PR TITLE
Fix positioning at right edge of narrow window

### DIFF
--- a/bootstrap-contextmenu.js
+++ b/bootstrap-contextmenu.js
@@ -147,8 +147,12 @@
 				Y = {"top": mouseY};
 			}
 
-			if ((mouseX + menuWidth > boundsX) && ((mouseX - menuWidth) > 0)) {
-				X = {"left": mouseX - menuWidth};
+			if (mouseX + menuWidth > boundsX) {
+				if((mouseX - menuWidth) > 0) {
+					X = {"left": mouseX - menuWidth};
+				} else {
+					X = {"left": mouseX - ((mouseX + menuWidth) - boundsX)};
+				}
 			} else {
 				X = {"left": mouseX};
 			}


### PR DESCRIPTION
If the window was too narrow to pop the menu to the left, it would go
off the right edge. The menu position is now clamped so that this will
not happen.
