### PR TITLE
Adjust the position of the context-menu by its offset parent position

### DIFF
--- a/bootstrap-contextmenu.js
+++ b/bootstrap-contextmenu.js
@@ -140,11 +140,11 @@
 				, menuHeight = $menu.find('.dropdown-menu').outerHeight()
 				, tp = {"position":"absolute"}
 				, Y, X;
-
+                
 			if (mouseY + menuHeight > boundsY) {
 				Y = {"top": mouseY - menuHeight + $(window).scrollTop()};
 			} else {
-				Y = {"top": mouseY + $(window).scrollTop()};
+				Y = {"top": mouseY + $(window).scrollTop() };
 			}
 
 			if ((mouseX + menuWidth > boundsX) && ((mouseX - menuWidth) > 0)) {
@@ -153,7 +153,14 @@
 				X = {"left": mouseX + $(window).scrollLeft()};
 			}
 
-			return $.extend(tp, Y, X);
+			// If the developer has positioned the context-menu's parent using absolute or relative positioning,
+			// the calculated mouse position will be incorrect.
+			// Adjust the position of the menu by its offset parent position.
+			var selectorPosition = $menu.offsetParent().offset();
+			X.left = X.left - selectorPosition.left;
+			Y.top = Y.top - selectorPosition.top;
+
+			return $.extend(tp, X , Y );
 		}
 
 		,clearMenus: function(e) {


### PR DESCRIPTION
Currently if a developer positions the context-menu DOM (or any of its parents) using absolute/relative positioning etc, the context-menu may be positioned incorrectly.

I've added code to account for the context-menus offset parent.
