### PR TITLE
using jquery object as target breaks jquery

### DIFF
--- a/bootstrap-contextmenu.js
+++ b/bootstrap-contextmenu.js
@@ -41,7 +41,7 @@
 			this.before = this.options.before || this.before
 			this.onItem = this.options.onItem || this.onItem
 			if (this.options.target)
-				this.$elements.attr('data-target',this.options.target)
+				this.$elements.data('target',this.options.target)
 
 			this.listen()
 		}
@@ -94,7 +94,7 @@
 			$('html')
 					.on('click.context.data-api', $.proxy(this.closemenu, this));
 
-			var $target = $(this.$elements.attr('data-target'));
+			var $target = $(this.$elements.data('target'));
 
 			$target.on('click.context.data-api', function (e) {
 				if($(this).data('_context_this_ref') == _this) {
@@ -113,12 +113,12 @@
 			this.$elements.off('.context.data-api').removeData('context');
 			$('html').off('.context.data-api');
 
-			var $target = $(this.$elements.attr('data-target'));
+			var $target = $(this.$elements.data('target'));
 			$target.off('.context.data-api');
 		}
 
 		,getMenu: function () {
-			var selector = this.$elements.attr('data-target')
+			var selector = this.$elements.data('target')
 				, $menu;
 
 			if (!selector) {


### PR DESCRIPTION
Hello,
Your code should support target option as jquery object because in structured programming sometimes we dont have id`s but we do have reference ot jquery objects and your code stricts user to use either id or class on context-menu div. Restriction is never good.

```
var target = $('#context-menu');
$('.context').contextmenu({
  target:target , 
 })
```

It can be fixed by replacing 

```
this.$elements.attr('data-target',this.options.target)
```

with

```
this.$elements.data('target',this.options.target)
```

I pulled above changes and now works flawlessly.
Now also accepts jQueryObjects/References as targets in options along-with id or class selector
