### PR TITLE
remove erroneous '.' from disabled class check

### DIFF
--- a/bootstrap-contextmenu.js
+++ b/bootstrap-contextmenu.js
@@ -112,7 +112,7 @@
 		}
 
 		,isDisabled: function() {
-			return this.$element.hasClass('.disabled') || 
+			return this.$element.hasClass('disabled') || 
 					this.$element.attr('disabled');
 		}
 

--- a/test/unit/bootstrap-contextmenu.js
+++ b/test/unit/bootstrap-contextmenu.js
@@ -11,9 +11,27 @@ $(function () {
 		ok(el.contextmenu()[0] === el[0], 'same element returned');
 	});
 
-	test('should not open context-menu if context is disabled', function () {
+	test('should not open context-menu if context is disabled via element disabled attribute', function () {
 		var contextHTML = '<div>' +
 				'<div id="main" data-toggle="context" data-target="#context-menu" disabled>' +
+				'  <div id="context-menu">' +
+				'    <ul class="dropdown-menu">' +
+				'      <li><a href="#">Action</a></li>' +
+				'      <li><a href="#">Something else here</a></li>' +
+				'      <li class="divider"></li>' +
+				'      <li><a href="#">Another link</a></li>' +
+				'   <ul>' +
+				'  </div>' +
+				'</div>' +
+				'</div>',
+			contextmenu = $(contextHTML).find('[data-toggle="context"]').contextmenu().trigger('contextmenu');
+		
+		ok(!contextmenu.find('#context-menu').hasClass('open'), 'open class added on contextmenu');
+	});
+
+	test('should not open context-menu if context is disabled via element disabled class', function () {
+		var contextHTML = '<div>' +
+				'<div id="main" data-toggle="context" data-target="#context-menu" class="disabled">' +
 				'  <div id="context-menu">' +
 				'    <ul class="dropdown-menu">' +
 				'      <li><a href="#">Action</a></li>' +


### PR DESCRIPTION
The jQuery hasClass method accepts just the class name without a period.  This patch allows you to disable a context menu with either the disabled class or disabled element attribute, as originally intended
