### PR TITLE
`before` function had to explicitly return true to show

### DIFF
--- a/bootstrap-contextmenu.js
+++ b/bootstrap-contextmenu.js
@@ -46,7 +46,7 @@
 
 			this.closemenu();
 
-			if (!this.before.call(this,e,$(e.currentTarget))) return;
+			if (this.before.call(this,e,$(e.currentTarget)) === false) return;
 
 			$menu = this.getMenu();
 			$menu.trigger(evt = $.Event('show.bs.context', relatedTarget));

--- a/test/unit/bootstrap-contextmenu.js
+++ b/test/unit/bootstrap-contextmenu.js
@@ -209,6 +209,42 @@ $(function () {
 		contextmenu.remove();
 	});
 
+	test('should not open context-menu if before returns false', function () {
+		var contextHTML = '<div>' +
+				'<div id="main" data-toggle="context" data-target="#context-menu">' +
+				'  <div id="context-menu">' +
+				'    <ul class="dropdown-menu">' +
+				'      <li><a href="#">Action</a></li>' +
+				'      <li><a href="#">Something else here</a></li>' +
+				'      <li class="divider"></li>' +
+				'      <li><a href="#">Another link</a></li>' +
+				'   <ul>' +
+				'  </div>' +
+				'</div>' +
+				'</div>',
+			contextmenu = $(contextHTML).find('[data-toggle="context"]').contextmenu({ before: function() { return false; }}).trigger('contextmenu');
+		
+		ok(!contextmenu.find('#context-menu').hasClass('open'), 'open class added on contextmenu');
+	});
+
+	test('should open context-menu if before does not return anything', function () {
+		var contextHTML = '<div>' +
+				'<div id="main" data-toggle="context" data-target="#context-menu">' +
+				'  <div id="context-menu">' +
+				'    <ul class="dropdown-menu">' +
+				'      <li><a href="#">Action</a></li>' +
+				'      <li><a href="#">Something else here</a></li>' +
+				'      <li class="divider"></li>' +
+				'      <li><a href="#">Another link</a></li>' +
+				'   <ul>' +
+				'  </div>' +
+				'</div>' +
+				'</div>',
+			contextmenu = $(contextHTML).find('[data-toggle="context"]').contextmenu({ before: function() { }}).trigger('contextmenu');
+		
+		ok(contextmenu.find('#context-menu').hasClass('open'), 'open class not added on contextmenu');
+	});
+
 	test('calls onItem callback if an menu item is clicked', function () {
 		var contextHTML = '<div>' + 
 				'<div id="main" data-toggle="context" data-target="#context-menu">' +


### PR DESCRIPTION
In the current code, the following code from the README.MD will not show the contextmenu:

```javascript
$('.context').contextmenu({
  target:'#context-menu', 
  before: function(e,context) {
  },
  onItem: function(context,e) {
  }
});
```

This is because the `before` function must return true in order to show. The documentation only talks about returning false to not show the context menu. I've committed a fix that will only not show the context menu if the before function returns false.