### PR TITLE
Update bootstrap-contextmenu.js

### DIFF
--- a/bootstrap-contextmenu.js
+++ b/bootstrap-contextmenu.js
@@ -159,7 +159,7 @@
 			// If context-menu's parent is positioned using absolute or relative positioning,
 			// the calculated mouse position will be incorrect.
 			// Adjust the position of the menu by its offset parent position.
-			parentOffset = $menu.offsetParent().offset();
+			parentOffset = $menu.offsetParent().offset() || { left: 0, top: 0};
 			X.left = X.left - parentOffset.left;
 			Y.top = Y.top - parentOffset.top;
  


### PR DESCRIPTION
fix error when the context menu doesn't exist, which is lead by offset() return undefined.