### PR TITLE
Fix bootstrap 2.x submenu compatibility

### DIFF
--- a/bootstrap-contextmenu.js
+++ b/bootstrap-contextmenu.js
@@ -52,7 +52,7 @@
 			$menu.trigger(evt = $.Event('show.bs.context', relatedTarget));
 
 			tp = this.getPosition(e, $menu);
-			items = 'li:not(.divider)';
+			items = 'li:not(.divider,.dropdown-submenu)';
 			$menu.attr('style', '')
 				.css(tp)
 				.addClass('open')
@@ -80,7 +80,7 @@
 			relatedTarget = { relatedTarget: this };
 			$menu.trigger(evt = $.Event('hide.bs.context', relatedTarget));
 
-			items = 'li:not(.divider)';
+			items = 'li:not(.divider,.dropdown-submenu)';
 			$menu.removeClass('open')
 				.off('click.context.data-api', items)
 				.trigger('hidden.bs.context', relatedTarget);


### PR DESCRIPTION
Fix an issue with the Bootstrap 2.x Dropdown submenu.
It was triggering the **onItem** N times (depending on n sub-levels)

P.S: Bootstrap 3.x don't have the submenu, but it's really easy to add (See: http://stackoverflow.com/questions/18023493/bootstrap-3-dropdown-sub-menu-missing)
