### PR TITLE
check if parameter "e" is undefined in function "closemenu"

### DIFF
--- a/bootstrap-contextmenu.js
+++ b/bootstrap-contextmenu.js
@@ -89,7 +89,8 @@
 				.off('click.context.data-api', $menu.selector);
 			// Don't propagate click event so other currently
 			// opened menus won't close.
-			e.stopPropagation();
+			if (undefined != e)
+				e.stopPropagation();
 		}
 
 		,keydown: function(e) {


### PR DESCRIPTION
Hi,
Thank you for this nice feature, I have found it really useful in my project. I have found however a small bug:
When I consequently right-click items that have a context menu, the menu appears only every second time! 
This is caused by the `closemenu` function, where the parameter `e` is undefined when called from the `show` function. I have added a small check for that.