### PR TITLE
Remove explicit bower version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "bootstrap-contextmenu",
   "main": "bootstrap-contextmenu.js",
-  "version": "0.3.4",
   "homepage": "https://github.com/sydcanem/bootstrap-contextmenu",
   "authors": [
     "sydcanem <icqhv.santos@gmail.com>"


### PR DESCRIPTION
Since is a deprecated Bower option and is ignored: https://github.com/bower/spec/blob/master/json.md#version
